### PR TITLE
Fixed empty freq.

### DIFF
--- a/WFD_Curses.py
+++ b/WFD_Curses.py
@@ -1354,12 +1354,13 @@ def statusline():
 
     suffix = ""
 
-    if strband == "OOB":
-        suffix = ""
-    elif int(freq) > 225000000:
-        suffix = "cm"
-    else:
-        suffix = "m"
+    if freq != "":
+        if strband == "OOB":
+            suffix = ""
+        elif int(freq) > 225000000:
+            suffix = "cm"
+        else:
+            suffix = "m"
 
     strband += suffix
 


### PR DESCRIPTION
Found this in the log 

06:31:32,648 root DEBUG getmode_rigctld: [Errno 32] Broken pipe
06:31:32,649 root INFO F: M:

And Yup a quick type in the terminal:

>>> f=''
>>> int(f)

Gives you:  ValueError: invalid literal for int() with base 10: ''

Our path was clear.